### PR TITLE
Fix LLM predictions workflow

### DIFF
--- a/.github/workflows/update-predictions.yml
+++ b/.github/workflows/update-predictions.yml
@@ -45,8 +45,8 @@ jobs:
       
       - name: Commit and push changes
         run: |
-          # Explicitly exclude .env and debug files
-          git add -A -- ':!.env' ':!*_debug.html'
+          # Rely on .gitignore to exclude .env and debug files
+          git add -A
           git commit -m "Update predictions via GitHub Action" || echo "No changes to commit"
           git push
         env:


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow
  - rely on `.gitignore` to skip `.env` and debug files during commit

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f767d5b888329913020d2c14661fb