### PR TITLE
Fix predictions updater

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Last updated: 2025-06-03T22:33:44.348Z -->
+  <!-- Last updated: 2025-06-03T22:41:50.238Z -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Sports Almanac</title>
@@ -543,63 +543,143 @@
         
         // Game data
         const GAMES = {
-            'wsh-ari': {
-                away: { team: 'Washington Nationals', abbr: 'WSH', record: '28-30' },
-                home: { team: 'Arizona Diamondbacks', abbr: 'ARI', record: '27-31' },
-                time: '04:10 PM EDT',
-                date: 'Sun, Jun 1',
-                venue: 'Chase Field, Phoenix, AZ'
-            },
-            'min-sea': {
-                away: { team: 'Minnesota Twins', abbr: 'MIN', record: '31-26' },
-                home: { team: 'Seattle Mariners', abbr: 'SEA', record: '31-26' },
-                time: '04:10 PM EDT',
-                date: 'Sun, Jun 1',
-                venue: 'T-Mobile Park, Seattle, WA'
-            },
-            'pit-sd': {
-                away: { team: 'Pittsburgh Pirates', abbr: 'PIT', record: '22-37' },
-                home: { team: 'San Diego Padres', abbr: 'SD', record: '32-24' },
-                time: '05:10 PM EDT',
-                date: 'Sun, Jun 1',
-                venue: 'Petco Park, San Diego, CA'
-            },
-            'nyy-lad': {
-                away: { team: 'New York Yankees', abbr: 'NYY', record: '35-22' },
-                home: { team: 'Los Angeles Dodgers', abbr: 'LAD', record: '36-22' },
-                time: '07:10 PM EDT',
-                date: 'Sun, Jun 1',
-                venue: 'Dodger Stadium, Los Angeles, CA'
-            }
-        };
+    "wsh-ari": {
+        "away": {
+            "team": "Washington Nationals",
+            "abbr": "WSH",
+            "record": "28-30"
+        },
+        "home": {
+            "team": "Arizona Diamondbacks",
+            "abbr": "ARI",
+            "record": "27-31"
+        },
+        "time": "12:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "Chase Field, Phoenix, AZ"
+    },
+    "min-sea": {
+        "away": {
+            "team": "Minnesota Twins",
+            "abbr": "MIN",
+            "record": "31-26"
+        },
+        "home": {
+            "team": "Seattle Mariners",
+            "abbr": "SEA",
+            "record": "31-26"
+        },
+        "time": "12:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "T-Mobile Park, Seattle, WA"
+    },
+    "pit-sd": {
+        "away": {
+            "team": "Pittsburgh Pirates",
+            "abbr": "PIT",
+            "record": "22-37"
+        },
+        "home": {
+            "team": "San Diego Padres",
+            "abbr": "SD",
+            "record": "32-24"
+        },
+        "time": "01:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "Petco Park, San Diego, CA"
+    },
+    "nyy-lad": {
+        "away": {
+            "team": "New York Yankees",
+            "abbr": "NYY",
+            "record": "35-22"
+        },
+        "home": {
+            "team": "Los Angeles Dodgers",
+            "abbr": "LAD",
+            "record": "36-22"
+        },
+        "time": "03:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "Dodger Stadium, Los Angeles, CA"
+    }
+};
         
         // Fallback predictions in case API calls fail
         const FALLBACK_PREDICTIONS = {
-            'wsh-ari': [
-                { source: 'OpenAI', text: 'The Diamondbacks have home field advantage but the Nationals have been playing better recently. The pitching matchup slightly favors Washington. Prediction: Nationals win 5-3.' },
-                { source: 'Anthropic', text: 'This matchup between Washington and Arizona should be competitive. Arizona\'s home field advantage will be a factor, but Washington has the better record. Expect a close game with Washington prevailing 4-3.' },
-                { source: 'Grok', text: 'Washington has been more consistent on the road this season. Arizona has struggled at home. Expect Washington to win this one 6-4.' },
-                { source: 'DeepSeek', text: 'Statistical analysis gives Washington a 53% win probability in this matchup against Arizona.' }
-            ],
-            'min-sea': [
-                { source: 'OpenAI', text: 'Both teams have identical records, making this a very even matchup. Seattle\'s home field advantage and strong pitching staff give them a slight edge. Prediction: Mariners win 3-2.' },
-                { source: 'Anthropic', text: 'This is a matchup of two evenly matched teams. The Mariners\' home field advantage could be the deciding factor. Expect a low-scoring game with Seattle winning 4-2.' },
-                { source: 'Grok', text: 'The Twins and Mariners both have strong pitching. This game will likely come down to bullpen performance. Seattle has the edge at home and should win 3-2.' },
-                { source: 'DeepSeek', text: 'Statistical models show this as a near-even matchup with Seattle having a slight 51% win probability due to home field advantage.' }
-            ],
-            'pit-sd': [
-                { source: 'OpenAI', text: 'The Padres have a significant advantage in this matchup. They have a much better record and are playing at home. The Pirates have struggled on the road this season. Prediction: Padres win 6-2.' },
-                { source: 'Anthropic', text: 'San Diego has the clear advantage in this matchup. Their offense has been clicking lately, and Pittsburgh has struggled with consistency. Expect the Padres to win comfortably, 7-3.' },
-                { source: 'Grok', text: 'The Padres should dominate this game. Their pitching staff has been excellent at home, and the Pirates have one of the worst road records in baseball. San Diego wins 5-1.' },
-                { source: 'DeepSeek', text: 'Statistical analysis heavily favors San Diego with a 68% win probability. The talent gap and home field advantage are significant factors.' }
-            ],
-            'nyy-lad': [
-                { source: 'OpenAI', text: 'This is a marquee matchup between two of baseball\'s most storied franchises. Both teams have similar records and elite talent. The Dodgers\' home field advantage gives them a slight edge. Prediction: Dodgers win 5-4.' },
-                { source: 'Anthropic', text: 'This Yankees-Dodgers matchup features two of the best teams in baseball. The pitching matchup is even, but the Dodgers have been slightly better at home. Expect a close game with the Dodgers winning 4-3.' },
-                { source: 'Grok', text: 'This potential World Series preview should be highly competitive. Both teams have powerful lineups and strong pitching. The Dodgers\' home field advantage could be the difference. Dodgers win 6-5 in a thriller.' },
-                { source: 'DeepSeek', text: 'Statistical models give the Dodgers a narrow 52% win probability in this evenly matched contest. Home field advantage is the primary differentiator.' }
-            ]
-        };
+    "wsh-ari": [
+        {
+            "source": "OpenAI",
+            "text": "Washington Nationals - Arizona Diamondbacks: 3-4\n\nThe Arizona Diamondbacks have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Washington Nationals's scoring opportunities."
+        },
+        {
+            "source": "Anthropic",
+            "text": "Washington Nationals - Arizona Diamondbacks: 1-5\n\nAfter analyzing both teams' strengths and weaknesses, the Arizona Diamondbacks appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Washington Nationals in this game."
+        },
+        {
+            "source": "Grok",
+            "text": "Washington Nationals - Arizona Diamondbacks: 3-3\n\nLooking at the batting averages and bullpen ERA, the Arizona Diamondbacks have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Chase Field, Phoenix, AZ."
+        },
+        {
+            "source": "DeepSeek",
+            "text": "Washington Nationals - Arizona Diamondbacks: 1-5\n\nStatistical analysis indicates the Arizona Diamondbacks have a 52% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
+        }
+    ],
+    "min-sea": [
+        {
+            "source": "OpenAI",
+            "text": "Minnesota Twins - Seattle Mariners: 2-4\n\nThe Seattle Mariners have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Minnesota Twins's scoring opportunities."
+        },
+        {
+            "source": "Anthropic",
+            "text": "Minnesota Twins - Seattle Mariners: 3-3\n\nAfter analyzing both teams' strengths and weaknesses, the Seattle Mariners appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Minnesota Twins in this game."
+        },
+        {
+            "source": "Grok",
+            "text": "Minnesota Twins - Seattle Mariners: 1-4\n\nLooking at the batting averages and bullpen ERA, the Seattle Mariners have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at T-Mobile Park, Seattle, WA."
+        },
+        {
+            "source": "DeepSeek",
+            "text": "Minnesota Twins - Seattle Mariners: 3-4\n\nStatistical analysis indicates the Seattle Mariners have a 52% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
+        }
+    ],
+    "pit-sd": [
+        {
+            "source": "OpenAI",
+            "text": "Pittsburgh Pirates - San Diego Padres: 2-5\n\nThe San Diego Padres have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Pittsburgh Pirates's scoring opportunities."
+        },
+        {
+            "source": "Anthropic",
+            "text": "Pittsburgh Pirates - San Diego Padres: 3-3\n\nAfter analyzing both teams' strengths and weaknesses, the San Diego Padres appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Pittsburgh Pirates in this game."
+        },
+        {
+            "source": "Grok",
+            "text": "Pittsburgh Pirates - San Diego Padres: 2-4\n\nLooking at the batting averages and bullpen ERA, the San Diego Padres have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Petco Park, San Diego, CA."
+        },
+        {
+            "source": "DeepSeek",
+            "text": "Pittsburgh Pirates - San Diego Padres: 1-3\n\nStatistical analysis indicates the San Diego Padres have a 62% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
+        }
+    ],
+    "nyy-lad": [
+        {
+            "source": "OpenAI",
+            "text": "New York Yankees - Los Angeles Dodgers: 2-6\n\nThe Los Angeles Dodgers have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the New York Yankees's scoring opportunities."
+        },
+        {
+            "source": "Anthropic",
+            "text": "New York Yankees - Los Angeles Dodgers: 1-6\n\nAfter analyzing both teams' strengths and weaknesses, the Los Angeles Dodgers appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the New York Yankees in this game."
+        },
+        {
+            "source": "Grok",
+            "text": "New York Yankees - Los Angeles Dodgers: 1-6\n\nLooking at the batting averages and bullpen ERA, the Los Angeles Dodgers have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Dodger Stadium, Los Angeles, CA."
+        },
+        {
+            "source": "DeepSeek",
+            "text": "New York Yankees - Los Angeles Dodgers: 2-5\n\nStatistical analysis indicates the Los Angeles Dodgers have a 52% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
+        }
+    ]
+};
         
         // Initialize the page
         document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- use slug ids for games so we can map to HTML
- rewrite `updateHtmlWithPredictions` to inject games and fallback data

## Testing
- `node -c scripts/llm-integration/fetch-and-predict.js`
- `HTTPS_PROXY= HTTP_PROXY= https_proxy= http_proxy= node scripts/llm-integration/fetch-and-predict.js` *(fails to scrape due to redirects but updates HTML with manual data)*

------
https://chatgpt.com/codex/tasks/task_e_683f78c899948329a8a5b4612ed33a95