### PR TITLE
Fix predictions display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <!-- Last updated: 2025-06-03T22:44:42.516Z -->
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Last updated: 2025-06-03T23:22:44.496Z -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Sports Almanac</title>
@@ -336,126 +334,118 @@
         <p class="subtitle">View predictions from multiple AI models for upcoming baseball games.</p>
         
         <div class="games-container">
-            <!-- Game 1: Washington Nationals vs Arizona Diamondbacks -->
-            <div class="game-card">
-                <div class="game-header">
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/wsh_logo.svg" alt="Washington Nationals logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">WSH</div>
-                        <div class="team-record">28-30</div>
+        <div class="game-card">
+            <div class="game-header">
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/wsh_logo.svg" alt="Washington Nationals logo" class="team-logo">
                     </div>
-                    <div class="vs">vs</div>
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/ari_logo.svg" alt="Arizona Diamondbacks logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">ARI</div>
-                        <div class="team-record">27-31</div>
+                    <div class="team-abbr">WSH</div>
+                    <div class="team-record">28-30</div>
+                </div>
+                <div class="vs">vs</div>
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/ari_logo.svg" alt="Arizona Diamondbacks logo" class="team-logo">
                     </div>
-                </div>
-                <div class="game-details">
-                    <div class="game-time">Sun, Jun 1</div>
-                    <div class="game-time">04:10 PM EDT</div>
-                    <div class="game-venue">Chase Field, Phoenix, AZ</div>
-                </div>
-                <button class="predictions-button" data-game-id="wsh-ari" onclick="togglePredictions(this)">Show Predictions</button>
-                <div class="predictions" id="predictions-wsh-ari">
-                    <!-- Predictions will be loaded here -->
+                    <div class="team-abbr">ARI</div>
+                    <div class="team-record">27-31</div>
                 </div>
             </div>
-            
-            <!-- Game 2: Minnesota Twins vs Seattle Mariners -->
-            <div class="game-card">
-                <div class="game-header">
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/min_logo.svg" alt="Minnesota Twins logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">MIN</div>
-                        <div class="team-record">31-26</div>
-                    </div>
-                    <div class="vs">vs</div>
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/sea_logo.svg" alt="Seattle Mariners logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">SEA</div>
-                        <div class="team-record">31-26</div>
-                    </div>
-                </div>
-                <div class="game-details">
-                    <div class="game-time">Sun, Jun 1</div>
-                    <div class="game-time">04:10 PM EDT</div>
-                    <div class="game-venue">T-Mobile Park, Seattle, WA</div>
-                </div>
-                <button class="predictions-button" data-game-id="min-sea" onclick="togglePredictions(this)">Show Predictions</button>
-                <div class="predictions" id="predictions-min-sea">
-                    <!-- Predictions will be loaded here -->
-                </div>
+            <div class="game-details">
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">12:10 AM EDT</div>
+                <div class="game-venue">Chase Field, Phoenix, AZ</div>
             </div>
-            
-            <!-- Game 3: Pittsburgh Pirates vs San Diego Padres -->
-            <div class="game-card">
-                <div class="game-header">
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/pit_logo.svg" alt="Pittsburgh Pirates logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">PIT</div>
-                        <div class="team-record">22-37</div>
-                    </div>
-                    <div class="vs">vs</div>
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/sd_logo.svg" alt="San Diego Padres logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">SD</div>
-                        <div class="team-record">32-24</div>
-                    </div>
-                </div>
-                <div class="game-details">
-                    <div class="game-time">Sun, Jun 1</div>
-                    <div class="game-time">05:10 PM EDT</div>
-                    <div class="game-venue">Petco Park, San Diego, CA</div>
-                </div>
-                <button class="predictions-button" data-game-id="pit-sd" onclick="togglePredictions(this)">Show Predictions</button>
-                <div class="predictions" id="predictions-pit-sd">
-                    <!-- Predictions will be loaded here -->
-                </div>
-            </div>
-            
-            <!-- Game 4: New York Yankees vs Los Angeles Dodgers -->
-            <div class="game-card">
-                <div class="game-header">
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/nyy_logo.svg" alt="New York Yankees logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">NYY</div>
-                        <div class="team-record">35-22</div>
-                    </div>
-                    <div class="vs">vs</div>
-                    <div class="team">
-                        <div class="team-logo">
-                            <img src="team-logos/lad_logo.svg" alt="Los Angeles Dodgers logo" class="team-logo">
-                        </div>
-                        <div class="team-abbr">LAD</div>
-                        <div class="team-record">36-22</div>
-                    </div>
-                </div>
-                <div class="game-details">
-                    <div class="game-time">Sun, Jun 1</div>
-                    <div class="game-time">07:10 PM EDT</div>
-                    <div class="game-venue">Dodger Stadium, Los Angeles, CA</div>
-                </div>
-                <button class="predictions-button" data-game-id="nyy-lad" onclick="togglePredictions(this)">Show Predictions</button>
-                <div class="predictions" id="predictions-nyy-lad">
-                    <!-- Predictions will be loaded here -->
-                </div>
+            <button class="predictions-button" data-game-id="wsh-ari" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-wsh-ari">
+                <!-- Predictions will be loaded here -->
             </div>
         </div>
+        <div class="game-card">
+            <div class="game-header">
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/min_logo.svg" alt="Minnesota Twins logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">MIN</div>
+                    <div class="team-record">31-26</div>
+                </div>
+                <div class="vs">vs</div>
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/sea_logo.svg" alt="Seattle Mariners logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">SEA</div>
+                    <div class="team-record">31-26</div>
+                </div>
+            </div>
+            <div class="game-details">
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">12:10 AM EDT</div>
+                <div class="game-venue">T-Mobile Park, Seattle, WA</div>
+            </div>
+            <button class="predictions-button" data-game-id="min-sea" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-min-sea">
+                <!-- Predictions will be loaded here -->
+            </div>
+        </div>
+        <div class="game-card">
+            <div class="game-header">
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/pit_logo.svg" alt="Pittsburgh Pirates logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">PIT</div>
+                    <div class="team-record">22-37</div>
+                </div>
+                <div class="vs">vs</div>
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/sd_logo.svg" alt="San Diego Padres logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">SD</div>
+                    <div class="team-record">32-24</div>
+                </div>
+            </div>
+            <div class="game-details">
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">01:10 AM EDT</div>
+                <div class="game-venue">Petco Park, San Diego, CA</div>
+            </div>
+            <button class="predictions-button" data-game-id="pit-sd" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-pit-sd">
+                <!-- Predictions will be loaded here -->
+            </div>
+        </div>
+        <div class="game-card">
+            <div class="game-header">
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/nyy_logo.svg" alt="New York Yankees logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">NYY</div>
+                    <div class="team-record">35-22</div>
+                </div>
+                <div class="vs">vs</div>
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/lad_logo.svg" alt="Los Angeles Dodgers logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">LAD</div>
+                    <div class="team-record">36-22</div>
+                </div>
+            </div>
+            <div class="game-details">
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">03:10 AM EDT</div>
+                <div class="game-venue">Dodger Stadium, Los Angeles, CA</div>
+            </div>
+            <button class="predictions-button" data-game-id="nyy-lad" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-nyy-lad">
+                <!-- Predictions will be loaded here -->
+            </div>
+        </div></div>
     </main>
     
     
@@ -470,437 +460,140 @@
         
         // Game data
         const GAMES = {
-    "chc-wsh": {
+    "wsh-ari": {
         "away": {
-            "team": "Chicago Cubs",
-            "abbr": "CHC",
-            "record": "37-22"
-        },
-        "home": {
             "team": "Washington Nationals",
             "abbr": "WSH",
-            "record": "28-31"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Washington Nationals Stadium"
-    },
-    "cle-nyy": {
-        "away": {
-            "team": "Cleveland Guardians",
-            "abbr": "CLE",
-            "record": "32-26"
+            "record": "28-30"
         },
         "home": {
-            "team": "New York Yankees",
-            "abbr": "NYY",
-            "record": "36-22"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "New York Yankees Stadium"
-    },
-    "phi-tor": {
-        "away": {
-            "team": "Philadelphia Phillies",
-            "abbr": "PHI",
-            "record": "36-23"
-        },
-        "home": {
-            "team": "Toronto Blue Jays",
-            "abbr": "TOR",
-            "record": "31-28"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Toronto Blue Jays Stadium"
-    },
-    "mil-cin": {
-        "away": {
-            "team": "Milwaukee Brewers",
-            "abbr": "MIL",
-            "record": "33-28"
-        },
-        "home": {
-            "team": "Cincinnati Reds",
-            "abbr": "CIN",
-            "record": "29-32"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Cincinnati Reds Stadium"
-    },
-    "laa-bos": {
-        "away": {
-            "team": "Los Angeles Angels",
-            "abbr": "LAA",
-            "record": "27-32"
-        },
-        "home": {
-            "team": "Boston Red Sox",
-            "abbr": "BOS",
-            "record": "29-33"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Boston Red Sox Stadium"
-    },
-    "ari-atl": {
-        "away": {
             "team": "Arizona Diamondbacks",
             "abbr": "ARI",
-            "record": "28-31"
-        },
-        "home": {
-            "team": "Atlanta Braves",
-            "abbr": "ATL",
             "record": "27-31"
         },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Atlanta Braves Stadium"
+        "time": "12:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "Chase Field, Phoenix, AZ"
     },
-    "tex-tb": {
+    "min-sea": {
         "away": {
-            "team": "Texas Rangers",
-            "abbr": "TEX",
-            "record": "29-31"
-        },
-        "home": {
-            "team": "Tampa Bay Rays",
-            "abbr": "TB",
-            "record": "30-29"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Tampa Bay Rays Stadium"
-    },
-    "det-cws": {
-        "away": {
-            "team": "Detroit Tigers",
-            "abbr": "DET",
-            "record": "40-21"
-        },
-        "home": {
-            "team": "Chicago White Sox",
-            "abbr": "CWS",
-            "record": "18-42"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Chicago White Sox Stadium"
-    },
-    "kc-stl": {
-        "away": {
-            "team": "Kansas City Royals",
-            "abbr": "KC",
-            "record": "31-29"
-        },
-        "home": {
-            "team": "St. Louis Cardinals",
-            "abbr": "STL",
-            "record": "33-26"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "St. Louis Cardinals Stadium"
-    },
-    "bal-sea": {
-        "away": {
-            "team": "Baltimore Orioles",
-            "abbr": "BAL",
-            "record": "22-36"
+            "team": "Minnesota Twins",
+            "abbr": "MIN",
+            "record": "31-26"
         },
         "home": {
             "team": "Seattle Mariners",
             "abbr": "SEA",
-            "record": "32-26"
+            "record": "31-26"
         },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Seattle Mariners Stadium"
+        "time": "12:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "T-Mobile Park, Seattle, WA"
     },
-    "sd-sf": {
+    "pit-sd": {
         "away": {
+            "team": "Pittsburgh Pirates",
+            "abbr": "PIT",
+            "record": "22-37"
+        },
+        "home": {
             "team": "San Diego Padres",
             "abbr": "SD",
-            "record": "34-24"
+            "record": "32-24"
         },
-        "home": {
-            "team": "San Francisco Giants",
-            "abbr": "SF",
-            "record": "33-27"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "San Francisco Giants Stadium"
+        "time": "01:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "Petco Park, San Diego, CA"
     },
-    "min-oak": {
+    "nyy-lad": {
         "away": {
-            "team": "Minnesota Twins",
-            "abbr": "MIN",
-            "record": "32-27"
-        },
-        "home": {
-            "team": "Oakland Athletics",
-            "abbr": "OAK",
-            "record": "23-38"
-        },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Oakland Athletics Stadium"
-    },
-    "nym-lad": {
-        "away": {
-            "team": "New York Mets",
-            "abbr": "NYM",
-            "record": "38-22"
+            "team": "New York Yankees",
+            "abbr": "NYY",
+            "record": "35-22"
         },
         "home": {
             "team": "Los Angeles Dodgers",
             "abbr": "LAD",
-            "record": "36-24"
+            "record": "36-22"
         },
-        "time": "Invalid Date EDT",
-        "date": "Invalid Date",
-        "venue": "Los Angeles Dodgers Stadium"
+        "time": "03:10 AM EDT",
+        "date": "Sun, Jun 1",
+        "venue": "Dodger Stadium, Los Angeles, CA"
     }
 };
         
         // Fallback predictions in case API calls fail
         const FALLBACK_PREDICTIONS = {
-    "chc-wsh": [
+    "wsh-ari": [
         {
             "source": "OpenAI",
-            "text": "Chicago Cubs - Washington Nationals: 3-3\n\nDespite playing away, the Chicago Cubs have shown better form with their 37-22 record compared to the Washington Nationals's 28-31. The Chicago Cubs's batting lineup has been more productive in recent games."
+            "text": "Washington Nationals - Arizona Diamondbacks: 2-3\n\nThe Arizona Diamondbacks have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Washington Nationals's scoring opportunities."
         },
         {
             "source": "Anthropic",
-            "text": "Chicago Cubs - Washington Nationals: 5-1\n\nThe Chicago Cubs have been performing exceptionally well on the road this season, which gives them an edge despite playing away. Their bullpen has been more reliable than the Washington Nationals's relief pitchers in close game situations."
+            "text": "Washington Nationals - Arizona Diamondbacks: 2-3\n\nAfter analyzing both teams' strengths and weaknesses, the Arizona Diamondbacks appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Washington Nationals in this game."
         },
         {
             "source": "Grok",
-            "text": "Chicago Cubs - Washington Nationals: 5-1\n\nThe Chicago Cubs have been road warriors this season with impressive away statistics. Their offensive production has been significantly better than the Washington Nationals's in the last 10 games."
+            "text": "Washington Nationals - Arizona Diamondbacks: 2-5\n\nLooking at the batting averages and bullpen ERA, the Arizona Diamondbacks have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Chase Field, Phoenix, AZ."
         },
         {
             "source": "DeepSeek",
-            "text": "Chicago Cubs - Washington Nationals: 4-1\n\nBased on advanced metrics, the Chicago Cubs have a 54% chance to win despite playing away from home. Their road OPS and pitching matchup advantages are significant factors in this prediction."
+            "text": "Washington Nationals - Arizona Diamondbacks: 1-3\n\nStatistical analysis indicates the Arizona Diamondbacks have a 52% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
         }
     ],
-    "cle-nyy": [
+    "min-sea": [
         {
             "source": "OpenAI",
-            "text": "Cleveland Guardians - New York Yankees: 1-4\n\nThe New York Yankees have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Cleveland Guardians's scoring opportunities."
+            "text": "Minnesota Twins - Seattle Mariners: 2-6\n\nThe Seattle Mariners have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Minnesota Twins's scoring opportunities."
         },
         {
             "source": "Anthropic",
-            "text": "Cleveland Guardians - New York Yankees: 2-4\n\nAfter analyzing both teams' strengths and weaknesses, the New York Yankees appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Cleveland Guardians in this game."
+            "text": "Minnesota Twins - Seattle Mariners: 3-5\n\nAfter analyzing both teams' strengths and weaknesses, the Seattle Mariners appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Minnesota Twins in this game."
         },
         {
             "source": "Grok",
-            "text": "Cleveland Guardians - New York Yankees: 2-3\n\nLooking at the batting averages and bullpen ERA, the New York Yankees have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at New York Yankees Stadium."
+            "text": "Minnesota Twins - Seattle Mariners: 2-4\n\nLooking at the batting averages and bullpen ERA, the Seattle Mariners have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at T-Mobile Park, Seattle, WA."
         },
         {
             "source": "DeepSeek",
-            "text": "Cleveland Guardians - New York Yankees: 2-5\n\nStatistical analysis indicates the New York Yankees have a 55% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
+            "text": "Minnesota Twins - Seattle Mariners: 2-4\n\nStatistical analysis indicates the Seattle Mariners have a 52% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
         }
     ],
-    "phi-tor": [
+    "pit-sd": [
         {
             "source": "OpenAI",
-            "text": "Philadelphia Phillies - Toronto Blue Jays: 5-1\n\nDespite playing away, the Philadelphia Phillies have shown better form with their 36-23 record compared to the Toronto Blue Jays's 31-28. The Philadelphia Phillies's batting lineup has been more productive in recent games."
+            "text": "Pittsburgh Pirates - San Diego Padres: 2-6\n\nThe San Diego Padres have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Pittsburgh Pirates's scoring opportunities."
         },
         {
             "source": "Anthropic",
-            "text": "Philadelphia Phillies - Toronto Blue Jays: 4-2\n\nThe Philadelphia Phillies have been performing exceptionally well on the road this season, which gives them an edge despite playing away. Their bullpen has been more reliable than the Toronto Blue Jays's relief pitchers in close game situations."
+            "text": "Pittsburgh Pirates - San Diego Padres: 1-5\n\nAfter analyzing both teams' strengths and weaknesses, the San Diego Padres appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Pittsburgh Pirates in this game."
         },
         {
             "source": "Grok",
-            "text": "Philadelphia Phillies - Toronto Blue Jays: 5-2\n\nThe Philadelphia Phillies have been road warriors this season with impressive away statistics. Their offensive production has been significantly better than the Toronto Blue Jays's in the last 10 games."
+            "text": "Pittsburgh Pirates - San Diego Padres: 3-6\n\nLooking at the batting averages and bullpen ERA, the San Diego Padres have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Petco Park, San Diego, CA."
         },
         {
             "source": "DeepSeek",
-            "text": "Philadelphia Phillies - Toronto Blue Jays: 6-1\n\nBased on advanced metrics, the Philadelphia Phillies have a 51% chance to win despite playing away from home. Their road OPS and pitching matchup advantages are significant factors in this prediction."
+            "text": "Pittsburgh Pirates - San Diego Padres: 1-3\n\nStatistical analysis indicates the San Diego Padres have a 62% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
         }
     ],
-    "mil-cin": [
+    "nyy-lad": [
         {
             "source": "OpenAI",
-            "text": "Milwaukee Brewers - Cincinnati Reds: 3-1\n\nDespite playing away, the Milwaukee Brewers have shown better form with their 33-28 record compared to the Cincinnati Reds's 29-32. The Milwaukee Brewers's batting lineup has been more productive in recent games."
+            "text": "New York Yankees - Los Angeles Dodgers: 3-5\n\nThe Los Angeles Dodgers have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the New York Yankees's scoring opportunities."
         },
         {
             "source": "Anthropic",
-            "text": "Milwaukee Brewers - Cincinnati Reds: 6-2\n\nThe Milwaukee Brewers have been performing exceptionally well on the road this season, which gives them an edge despite playing away. Their bullpen has been more reliable than the Cincinnati Reds's relief pitchers in close game situations."
+            "text": "New York Yankees - Los Angeles Dodgers: 3-3\n\nAfter analyzing both teams' strengths and weaknesses, the Los Angeles Dodgers appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the New York Yankees in this game."
         },
         {
             "source": "Grok",
-            "text": "Milwaukee Brewers - Cincinnati Reds: 5-3\n\nThe Milwaukee Brewers have been road warriors this season with impressive away statistics. Their offensive production has been significantly better than the Cincinnati Reds's in the last 10 games."
+            "text": "New York Yankees - Los Angeles Dodgers: 1-4\n\nLooking at the batting averages and bullpen ERA, the Los Angeles Dodgers have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Dodger Stadium, Los Angeles, CA."
         },
         {
             "source": "DeepSeek",
-            "text": "Milwaukee Brewers - Cincinnati Reds: 5-1\n\nBased on advanced metrics, the Milwaukee Brewers have a 51% chance to win despite playing away from home. Their road OPS and pitching matchup advantages are significant factors in this prediction."
-        }
-    ],
-    "laa-bos": [
-        {
-            "source": "OpenAI",
-            "text": "Los Angeles Angels - Boston Red Sox: 3-5\n\nThe Boston Red Sox have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Los Angeles Angels's scoring opportunities."
-        },
-        {
-            "source": "Anthropic",
-            "text": "Los Angeles Angels - Boston Red Sox: 2-3\n\nAfter analyzing both teams' strengths and weaknesses, the Boston Red Sox appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Los Angeles Angels in this game."
-        },
-        {
-            "source": "Grok",
-            "text": "Los Angeles Angels - Boston Red Sox: 2-6\n\nLooking at the batting averages and bullpen ERA, the Boston Red Sox have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Boston Red Sox Stadium."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "Los Angeles Angels - Boston Red Sox: 1-3\n\nStatistical analysis indicates the Boston Red Sox have a 53% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
-        }
-    ],
-    "ari-atl": [
-        {
-            "source": "OpenAI",
-            "text": "Arizona Diamondbacks - Atlanta Braves: 3-6\n\nThe Atlanta Braves have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Arizona Diamondbacks's scoring opportunities."
-        },
-        {
-            "source": "Anthropic",
-            "text": "Arizona Diamondbacks - Atlanta Braves: 1-6\n\nAfter analyzing both teams' strengths and weaknesses, the Atlanta Braves appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Arizona Diamondbacks in this game."
-        },
-        {
-            "source": "Grok",
-            "text": "Arizona Diamondbacks - Atlanta Braves: 2-5\n\nLooking at the batting averages and bullpen ERA, the Atlanta Braves have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Atlanta Braves Stadium."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "Arizona Diamondbacks - Atlanta Braves: 3-5\n\nStatistical analysis indicates the Atlanta Braves have a 52% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
-        }
-    ],
-    "tex-tb": [
-        {
-            "source": "OpenAI",
-            "text": "Texas Rangers - Tampa Bay Rays: 2-3\n\nThe Tampa Bay Rays have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Texas Rangers's scoring opportunities."
-        },
-        {
-            "source": "Anthropic",
-            "text": "Texas Rangers - Tampa Bay Rays: 3-5\n\nAfter analyzing both teams' strengths and weaknesses, the Tampa Bay Rays appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Texas Rangers in this game."
-        },
-        {
-            "source": "Grok",
-            "text": "Texas Rangers - Tampa Bay Rays: 2-4\n\nLooking at the batting averages and bullpen ERA, the Tampa Bay Rays have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Tampa Bay Rays Stadium."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "Texas Rangers - Tampa Bay Rays: 1-6\n\nStatistical analysis indicates the Tampa Bay Rays have a 54% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
-        }
-    ],
-    "det-cws": [
-        {
-            "source": "OpenAI",
-            "text": "Detroit Tigers - Chicago White Sox: 5-2\n\nDespite playing away, the Detroit Tigers have shown better form with their 40-21 record compared to the Chicago White Sox's 18-42. The Detroit Tigers's batting lineup has been more productive in recent games."
-        },
-        {
-            "source": "Anthropic",
-            "text": "Detroit Tigers - Chicago White Sox: 5-3\n\nThe Detroit Tigers have been performing exceptionally well on the road this season, which gives them an edge despite playing away. Their bullpen has been more reliable than the Chicago White Sox's relief pitchers in close game situations."
-        },
-        {
-            "source": "Grok",
-            "text": "Detroit Tigers - Chicago White Sox: 6-3\n\nThe Detroit Tigers have been road warriors this season with impressive away statistics. Their offensive production has been significantly better than the Chicago White Sox's in the last 10 games."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "Detroit Tigers - Chicago White Sox: 6-1\n\nBased on advanced metrics, the Detroit Tigers have a 65% chance to win despite playing away from home. Their road OPS and pitching matchup advantages are significant factors in this prediction."
-        }
-    ],
-    "kc-stl": [
-        {
-            "source": "OpenAI",
-            "text": "Kansas City Royals - St. Louis Cardinals: 2-6\n\nThe St. Louis Cardinals have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Kansas City Royals's scoring opportunities."
-        },
-        {
-            "source": "Anthropic",
-            "text": "Kansas City Royals - St. Louis Cardinals: 3-4\n\nAfter analyzing both teams' strengths and weaknesses, the St. Louis Cardinals appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Kansas City Royals in this game."
-        },
-        {
-            "source": "Grok",
-            "text": "Kansas City Royals - St. Louis Cardinals: 1-3\n\nLooking at the batting averages and bullpen ERA, the St. Louis Cardinals have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at St. Louis Cardinals Stadium."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "Kansas City Royals - St. Louis Cardinals: 1-3\n\nStatistical analysis indicates the St. Louis Cardinals have a 54% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
-        }
-    ],
-    "bal-sea": [
-        {
-            "source": "OpenAI",
-            "text": "Baltimore Orioles - Seattle Mariners: 3-6\n\nThe Seattle Mariners have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the Baltimore Orioles's scoring opportunities."
-        },
-        {
-            "source": "Anthropic",
-            "text": "Baltimore Orioles - Seattle Mariners: 1-3\n\nAfter analyzing both teams' strengths and weaknesses, the Seattle Mariners appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the Baltimore Orioles in this game."
-        },
-        {
-            "source": "Grok",
-            "text": "Baltimore Orioles - Seattle Mariners: 1-3\n\nLooking at the batting averages and bullpen ERA, the Seattle Mariners have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Seattle Mariners Stadium."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "Baltimore Orioles - Seattle Mariners: 1-6\n\nStatistical analysis indicates the Seattle Mariners have a 61% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
-        }
-    ],
-    "sd-sf": [
-        {
-            "source": "OpenAI",
-            "text": "San Diego Padres - San Francisco Giants: 2-5\n\nThe San Francisco Giants have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the San Diego Padres's scoring opportunities."
-        },
-        {
-            "source": "Anthropic",
-            "text": "San Diego Padres - San Francisco Giants: 1-6\n\nAfter analyzing both teams' strengths and weaknesses, the San Francisco Giants appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the San Diego Padres in this game."
-        },
-        {
-            "source": "Grok",
-            "text": "San Diego Padres - San Francisco Giants: 2-6\n\nLooking at the batting averages and bullpen ERA, the San Francisco Giants have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at San Francisco Giants Stadium."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "San Diego Padres - San Francisco Giants: 2-3\n\nStatistical analysis indicates the San Francisco Giants have a 51% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
-        }
-    ],
-    "min-oak": [
-        {
-            "source": "OpenAI",
-            "text": "Minnesota Twins - Oakland Athletics: 4-2\n\nDespite playing away, the Minnesota Twins have shown better form with their 32-27 record compared to the Oakland Athletics's 23-38. The Minnesota Twins's batting lineup has been more productive in recent games."
-        },
-        {
-            "source": "Anthropic",
-            "text": "Minnesota Twins - Oakland Athletics: 4-1\n\nThe Minnesota Twins have been performing exceptionally well on the road this season, which gives them an edge despite playing away. Their bullpen has been more reliable than the Oakland Athletics's relief pitchers in close game situations."
-        },
-        {
-            "source": "Grok",
-            "text": "Minnesota Twins - Oakland Athletics: 3-2\n\nThe Minnesota Twins have been road warriors this season with impressive away statistics. Their offensive production has been significantly better than the Oakland Athletics's in the last 10 games."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "Minnesota Twins - Oakland Athletics: 3-3\n\nBased on advanced metrics, the Minnesota Twins have a 56% chance to win despite playing away from home. Their road OPS and pitching matchup advantages are significant factors in this prediction."
-        }
-    ],
-    "nym-lad": [
-        {
-            "source": "OpenAI",
-            "text": "New York Mets - Los Angeles Dodgers: 1-4\n\nThe Los Angeles Dodgers have a stronger record and home field advantage gives them the edge in this matchup. Their pitching staff has been more consistent recently which should limit the New York Mets's scoring opportunities."
-        },
-        {
-            "source": "Anthropic",
-            "text": "New York Mets - Los Angeles Dodgers: 3-6\n\nAfter analyzing both teams' strengths and weaknesses, the Los Angeles Dodgers appear to have the advantage playing at home. Their recent performance and pitching rotation matchup favorably against the New York Mets in this game."
-        },
-        {
-            "source": "Grok",
-            "text": "New York Mets - Los Angeles Dodgers: 1-3\n\nLooking at the batting averages and bullpen ERA, the Los Angeles Dodgers have clear advantages in key statistical categories. Their home record this season suggests they'll continue their strong performance at Los Angeles Dodgers Stadium."
-        },
-        {
-            "source": "DeepSeek",
-            "text": "New York Mets - Los Angeles Dodgers: 1-4\n\nStatistical analysis indicates the Los Angeles Dodgers have a 51% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
+            "text": "New York Yankees - Los Angeles Dodgers: 2-4\n\nStatistical analysis indicates the Los Angeles Dodgers have a 52% win probability in this matchup. Key factors include their home/away splits and superior performance in one-run games this season."
         }
     ]
 };
@@ -1242,5 +935,6 @@
         Predictions are generated by AI and are for entertainment purposes only.
         Do not use for betting advice.
     </div>
-</body>
-</html>
+
+
+</body></html>


### PR DESCRIPTION
## Summary
- update index.html with new matchups and fallback predictions
- update the prediction update script to also refresh the game card markup
- fix date parsing in scraper

## Testing
- `npm run lint`
- `node scripts/llm-integration/fetch-and-predict.js` *(fails to fetch real data but falls back to manual games and updates index.html)*

------
https://chatgpt.com/codex/tasks/task_e_683f830b243083299cc298d09329ee3c