### PR TITLE
Add build script for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules/
 .Trashes
 ehthumbs.db
 Thumbs.db
+out/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ npm start
 ```
 The `update` command fetches games, queries the LLMs and writes predictions to MongoDB.
 `npm start` launches a local Express server on port 3000. Visit http://localhost:3000 to view the results.
+
+To generate the static files for GitHub Pages, run:
+
+```bash
+npm run build
+```
+The `build` script outputs the site to the `out/` directory.
 ## Automation
 The workflow defined in `.github/workflows/update-predictions.yml` populates the
 environment from GitHub secrets and runs the update script every six hours so the database stays current.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+async function copyDir(src, dest) {
+  await fs.promises.mkdir(dest, { recursive: true });
+  for (const entry of await fs.promises.readdir(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else {
+      await fs.promises.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+async function build() {
+  const outDir = path.join(__dirname, 'out');
+  await fs.promises.rm(outDir, { recursive: true, force: true });
+  await fs.promises.mkdir(outDir, { recursive: true });
+
+  await fs.promises.copyFile(path.join(__dirname, 'index.html'), path.join(outDir, 'index.html'));
+
+  const logosSrc = path.join(__dirname, 'team-logos');
+  if (fs.existsSync(logosSrc)) {
+    await copyDir(logosSrc, path.join(outDir, 'team-logos'));
+  }
+
+  const publicSrc = path.join(__dirname, 'public');
+  if (fs.existsSync(publicSrc)) {
+    await copyDir(publicSrc, path.join(outDir, 'public'));
+  }
+
+  console.log('Static site built in', outDir);
+}
+
+build().catch(err => {
+  console.error('Build failed:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node server.js",
-    "update": "node scripts/llm-integration/fetch-and-predict.js"
+    "update": "node scripts/llm-integration/fetch-and-predict.js",
+    "build": "node build.js"
   },
   "dependencies": {
     "axios": "^1.9.0",


### PR DESCRIPTION
## Summary
- add simple `build.js` to copy static files into `out/`
- call script from new `npm run build` command
- ignore generated `out/` directory
- document build step in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68406ee56b6083298fcc3a0041fdffcf