### PR TITLE
Fix error handling for games fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,8 +422,12 @@ async function loadGames(){
     const data = await res.json();
     renderGames(data);
   } catch(e){
-    document.getElementById('games').innerText='Failed to load games';
-    console.error(e);
+    console.error('Failed to load live games:', e);
+    const err=document.createElement('p');
+    err.style.color='red';
+    err.style.textAlign='center';
+    err.textContent='Failed to load live games.';
+    document.body.insertBefore(err, document.getElementById('games'));
   }
 }
 function renderGames(games){


### PR DESCRIPTION
## Summary
- keep pre-rendered games when the `/api/games` request fails
- show a separate error message instead of clearing the content

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840789995a08329a621376ebb2fdd5b