### PR TITLE
Fix LLM API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ DATA_SOURCE_URL=https://www.dratings.com/predictor/mlb-baseball-predictions/
 `MONGODB_DB_NAME` controls which database the predictions are stored in.  The default
 is `ai-sports-almanac` if the variable is omitted.
 
-The prediction service and the demo page both use OpenAI's `gpt-3.5-turbo` model for consistency.
+The prediction service and the demo page both use OpenAI's `gpt-4o` model for consistency.
 
 ## Running locally
 

--- a/scripts/llm-integration/llm-prediction-service.js
+++ b/scripts/llm-integration/llm-prediction-service.js
@@ -60,7 +60,7 @@ Keep your explanation concise and focus only on this specific game.`;
       const response = await axios.post(
         'https://api.openai.com/v1/chat/completions',
         {
-          model: 'gpt-3.5-turbo',
+          model: 'gpt-4o',
           messages: [
             { role: 'system', content: 'You are a sports prediction AI specializing in MLB baseball.' },
             { role: 'user', content: prompt }
@@ -101,7 +101,7 @@ Keep your explanation concise and focus only on this specific game.`;
       const response = await axios.post(
         'https://api.anthropic.com/v1/messages',
         {
-          model: 'claude-3-sonnet-20240229',
+          model: 'claude-3-5-sonnet-20241022',
           max_tokens: 150,
           messages: [
             { role: 'user', content: prompt }
@@ -138,9 +138,9 @@ Keep your explanation concise and focus only on this specific game.`;
     try {
       const prompt = this.generatePrompt(game);
       
-      // Note: This is a placeholder as Grok's API details may vary
+      // Updated endpoint for xAI's Grok API
       const response = await axios.post(
-        'https://api.grok.x/v1/chat/completions',
+        'https://api.x.ai/v1/chat/completions',
         {
           model: 'grok-1',
           messages: [
@@ -181,7 +181,7 @@ Keep your explanation concise and focus only on this specific game.`;
       const prompt = this.generatePrompt(game);
       
       const response = await axios.post(
-        'https://api.deepseek.com/v1/chat/completions',
+        'https://api.deepseek.com/chat/completions',
         {
           model: 'deepseek-chat',
           messages: [


### PR DESCRIPTION
## Summary
- update OpenAI to `gpt-4o`
- use Anthropic `claude-3-5-sonnet-20241022`
- fix Grok domain to `api.x.ai`
- adjust DeepSeek endpoint
- docs: mention `gpt-4o`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684091609ff883298df023adb9c51c5a