### PR TITLE
Improve LLM API integration and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ DATA_SOURCE_URL=https://www.dratings.com/predictor/mlb-baseball-predictions/
 `MONGODB_DB_NAME` controls which database the predictions are stored in.  The default
 is `ai-sports-almanac` if the variable is omitted.
 
+The update script queries **four** different LLM providers (OpenAI, Anthropic, Grok and DeepSeek) for each game. Ensure all API keys are configured or the script will fall back to basic predictions.
+
 The prediction service and the demo page both use OpenAI's `gpt-4o` model for consistency.
 
 ## Running locally

--- a/scripts/llm-integration/fetch-and-predict.js
+++ b/scripts/llm-integration/fetch-and-predict.js
@@ -549,12 +549,17 @@ async function main() {
       try {
         // Get predictions from all LLM providers
         const predictions = await llmService.getAllPredictions(game);
-        
+
         // Only update predictions that were successfully retrieved
         if (predictions.openai) game.predictions.openai = predictions.openai;
         if (predictions.anthropic) game.predictions.anthropic = predictions.anthropic;
         if (predictions.grok) game.predictions.grok = predictions.grok;
         if (predictions.deepseek) game.predictions.deepseek = predictions.deepseek;
+
+        const anySuccess = Object.values(predictions.success || {}).some(v => v);
+        if (!anySuccess) {
+          throw new Error('All LLM API calls failed');
+        }
         
         // Store predictions in MongoDB if connected
         if (mongoConnected) {
@@ -572,6 +577,7 @@ async function main() {
       } catch (error) {
         console.warn(`Error generating predictions for game ${game.id}:`, error.message);
         console.log(`Using fallback predictions for game ${game.id}`);
+        throw error;
       }
     }
     
@@ -607,6 +613,7 @@ async function main() {
     } catch (htmlError) {
       console.error('Failed to update HTML with timestamp:', htmlError);
     }
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- update README with a note that four LLM providers are queried
- improve logging and success detection in fetch-and-predict
- exit with a failure code when all APIs fail
- return success flags from llm-prediction-service and log request failures

## Testing
- `npm install`
- `npm run update` *(fails: Maximum number of redirects exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6840b0e781048329976282b54dbf9983