### PR TITLE
Fix scraper date parsing and timezone display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html><html lang="en"><head>
-  <!-- Last updated: 2025-06-04T19:06:20.572Z -->
+  <!-- Last updated: 2025-06-04T20:52:31.954Z -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI Sports Almanac</title>
@@ -26,279 +26,27 @@
             <div class="game-header">
                 <div class="team">
                     <div class="team-logo">
-                        <img src="team-logos/hou_logo.svg" alt="Houston Astros logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">HOU</div>
-                    <div class="team-record">33-27</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/pit_logo.svg" alt="Pittsburgh Pirates logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">PIT</div>
-                    <div class="team-record">22-39</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">10:40 PM EDT</div>
-                <div class="game-venue">Pittsburgh Pirates Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="hou-pit" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-hou-pit">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/chc_logo.svg" alt="Chicago Cubs logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">CHC</div>
-                    <div class="team-record">38-22</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
                         <img src="team-logos/wsh_logo.svg" alt="Washington Nationals logo" class="team-logo">
                     </div>
                     <div class="team-abbr">WSH</div>
-                    <div class="team-record">28-32</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">10:45 PM EDT</div>
-                <div class="game-venue">Washington Nationals Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="chc-wsh" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-chc-wsh">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/cle_logo.svg" alt="Cleveland Guardians logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">CLE</div>
-                    <div class="team-record">32-27</div>
+                    <div class="team-record">28-30</div>
                 </div>
                 <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/nyy_logo.svg" alt="New York Yankees logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">NYY</div>
-                    <div class="team-record">37-22</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">11:05 PM EDT</div>
-                <div class="game-venue">New York Yankees Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="cle-nyy" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-cle-nyy">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/phi_logo.svg" alt="Philadelphia Phillies logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">PHI</div>
-                    <div class="team-record">37-23</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/tor_logo.svg" alt="Toronto Blue Jays logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">TOR</div>
-                    <div class="team-record">31-29</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">11:07 PM EDT</div>
-                <div class="game-venue">Toronto Blue Jays Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="phi-tor" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-phi-tor">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
                 <div class="team">
                     <div class="team-logo">
                         <img src="team-logos/ari_logo.svg" alt="Arizona Diamondbacks logo" class="team-logo">
                     </div>
                     <div class="team-abbr">ARI</div>
-                    <div class="team-record">29-31</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/atl_logo.svg" alt="Atlanta Braves logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">ATL</div>
-                    <div class="team-record">27-32</div>
+                    <div class="team-record">27-31</div>
                 </div>
             </div>
             <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">11:15 PM EDT</div>
-                <div class="game-venue">Atlanta Braves Stadium</div>
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">12:10 AM EDT</div>
+                <div class="game-venue">Chase Field, Phoenix, AZ</div>
             </div>
-            <button class="predictions-button" data-game-id="ari-atl" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-ari-atl">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/tex_logo.svg" alt="Texas Rangers logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">TEX</div>
-                    <div class="team-record">29-32</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/tb_logo.svg" alt="Tampa Bay Rays logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">TB</div>
-                    <div class="team-record">31-29</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">11:35 PM EDT</div>
-                <div class="game-venue">Tampa Bay Rays Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="tex-tb" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-tex-tb">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/det_logo.svg" alt="Detroit Tigers logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">DET</div>
-                    <div class="team-record">40-22</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/cws_logo.svg" alt="Chicago White Sox logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">CWS</div>
-                    <div class="team-record">19-42</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">11:40 PM EDT</div>
-                <div class="game-venue">Chicago White Sox Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="det-cws" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-det-cws">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/kc_logo.svg" alt="Kansas City Royals logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">KC</div>
-                    <div class="team-record">32-29</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/stl_logo.svg" alt="St. Louis Cardinals logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">STL</div>
-                    <div class="team-record">33-27</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">11:45 PM EDT</div>
-                <div class="game-venue">St. Louis Cardinals Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="kc-stl" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-kc-stl">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/bal_logo.svg" alt="Baltimore Orioles logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">BAL</div>
-                    <div class="team-record">23-36</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/sea_logo.svg" alt="Seattle Mariners logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">SEA</div>
-                    <div class="team-record">32-27</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">01:40 AM EDT</div>
-                <div class="game-venue">Seattle Mariners Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="bal-sea" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-bal-sea">
-                <!-- Predictions will be loaded here -->
-            </div>
-        </div>
-        <div class="game-card">
-            <div class="game-header">
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/sd_logo.svg" alt="San Diego Padres logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">SD</div>
-                    <div class="team-record">35-24</div>
-                </div>
-                <div class="vs">vs</div>
-                <div class="team">
-                    <div class="team-logo">
-                        <img src="team-logos/sf_logo.svg" alt="San Francisco Giants logo" class="team-logo">
-                    </div>
-                    <div class="team-abbr">SF</div>
-                    <div class="team-record">33-28</div>
-                </div>
-            </div>
-            <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">01:45 AM EDT</div>
-                <div class="game-venue">San Francisco Giants Stadium</div>
-            </div>
-            <button class="predictions-button" data-game-id="sd-sf" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-sd-sf">
+            <button class="predictions-button" data-game-id="wsh-ari" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-wsh-ari">
                 <!-- Predictions will be loaded here -->
             </div>
         </div>
@@ -309,24 +57,24 @@
                         <img src="team-logos/min_logo.svg" alt="Minnesota Twins logo" class="team-logo">
                     </div>
                     <div class="team-abbr">MIN</div>
-                    <div class="team-record">33-27</div>
+                    <div class="team-record">31-26</div>
                 </div>
                 <div class="vs">vs</div>
                 <div class="team">
                     <div class="team-logo">
-                        <img src="team-logos/oak_logo.svg" alt="Oakland Athletics logo" class="team-logo">
+                        <img src="team-logos/sea_logo.svg" alt="Seattle Mariners logo" class="team-logo">
                     </div>
-                    <div class="team-abbr">OAK</div>
-                    <div class="team-record">23-39</div>
+                    <div class="team-abbr">SEA</div>
+                    <div class="team-record">31-26</div>
                 </div>
             </div>
             <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">02:05 AM EDT</div>
-                <div class="game-venue">Oakland Athletics Stadium</div>
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">12:10 AM EDT</div>
+                <div class="game-venue">T-Mobile Park, Seattle, WA</div>
             </div>
-            <button class="predictions-button" data-game-id="min-oak" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-min-oak">
+            <button class="predictions-button" data-game-id="min-sea" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-min-sea">
                 <!-- Predictions will be loaded here -->
             </div>
         </div>
@@ -334,10 +82,38 @@
             <div class="game-header">
                 <div class="team">
                     <div class="team-logo">
-                        <img src="team-logos/nym_logo.svg" alt="New York Mets logo" class="team-logo">
+                        <img src="team-logos/pit_logo.svg" alt="Pittsburgh Pirates logo" class="team-logo">
                     </div>
-                    <div class="team-abbr">NYM</div>
-                    <div class="team-record">38-23</div>
+                    <div class="team-abbr">PIT</div>
+                    <div class="team-record">22-37</div>
+                </div>
+                <div class="vs">vs</div>
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/sd_logo.svg" alt="San Diego Padres logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">SD</div>
+                    <div class="team-record">32-24</div>
+                </div>
+            </div>
+            <div class="game-details">
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">01:10 AM EDT</div>
+                <div class="game-venue">Petco Park, San Diego, CA</div>
+            </div>
+            <button class="predictions-button" data-game-id="pit-sd" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-pit-sd">
+                <!-- Predictions will be loaded here -->
+            </div>
+        </div>
+        <div class="game-card">
+            <div class="game-header">
+                <div class="team">
+                    <div class="team-logo">
+                        <img src="team-logos/nyy_logo.svg" alt="New York Yankees logo" class="team-logo">
+                    </div>
+                    <div class="team-abbr">NYY</div>
+                    <div class="team-record">35-22</div>
                 </div>
                 <div class="vs">vs</div>
                 <div class="team">
@@ -345,16 +121,16 @@
                         <img src="team-logos/lad_logo.svg" alt="Los Angeles Dodgers logo" class="team-logo">
                     </div>
                     <div class="team-abbr">LAD</div>
-                    <div class="team-record">37-24</div>
+                    <div class="team-record">36-22</div>
                 </div>
             </div>
             <div class="game-details">
-                <div class="game-time">Thu, Jun 5</div>
-                <div class="game-time">02:10 AM EDT</div>
-                <div class="game-venue">Los Angeles Dodgers Stadium</div>
+                <div class="game-time">Sun, Jun 1</div>
+                <div class="game-time">03:10 AM EDT</div>
+                <div class="game-venue">Dodger Stadium, Los Angeles, CA</div>
             </div>
-            <button class="predictions-button" data-game-id="nym-lad" onclick="togglePredictions(this)">Show Predictions</button>
-            <div class="predictions" id="predictions-nym-lad">
+            <button class="predictions-button" data-game-id="nyy-lad" onclick="togglePredictions(this)">Show Predictions</button>
+            <div class="predictions" id="predictions-nyy-lad">
                 <!-- Predictions will be loaded here -->
             </div>
         </div></div>
@@ -385,7 +161,7 @@ function renderGames(games){
       <div>vs</div>
       <div class="team"><div class="team-logo"><img src="${g.homeTeam.logo}" alt="${g.homeTeam.abbreviation}"></div><div>${g.homeTeam.abbreviation}</div></div>
     </div>
-    <div class="game-details" style="text-align:center;padding-bottom:0.5rem;font-size:0.9rem;">${new Date(g.gameTime).toLocaleString()} - ${g.venue}</div>
+    <div class="game-details" style="text-align:center;padding-bottom:0.5rem;font-size:0.9rem;">${new Date(g.gameTime).toLocaleString('en-US',{timeZone:'America/New_York',hour:'numeric',minute:'2-digit',hour12:true,timeZoneName:'short'})} - ${g.venue}</div>
     <button onclick="togglePredictions(this)">Show Predictions</button>
     <div class="predictions"><ul>${g.predictions.map(p=>`<li><strong>${p.source}:</strong> ${p.text}</li>`).join('')}</ul></div>`;
     container.appendChild(card);


### PR DESCRIPTION
## Summary
- improve regex when parsing Dratings game times and add fallback logic
- recognize more team name variants
- show game times in Eastern Time on the client

## Testing
- `npm run update` *(fails: Maximum number of redirects)*

------
https://chatgpt.com/codex/tasks/task_e_6840b184424c8329a1d3536fa2c29d1f