### PR TITLE
Update Grok integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GROK_API_KEY=
+GROK_MODEL=grok-3-mini-fast-latest
 DEEPSEEK_API_KEY=
 
 # MongoDB Connection

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ these variables:
 OPENAI_API_KEY=your_openai_key
 ANTHROPIC_API_KEY=your_anthropic_key
 GROK_API_KEY=your_grok_key
+GROK_MODEL=grok-3-mini-fast-latest
 DEEPSEEK_API_KEY=your_deepseek_key
 MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net
 MONGODB_DB_NAME=ai-sports-almanac

--- a/scripts/llm-integration/llm-prediction-service.js
+++ b/scripts/llm-integration/llm-prediction-service.js
@@ -16,6 +16,9 @@ class LLMPredictionService {
       grok: apiKeys.grok || process.env.GROK_API_KEY,
       deepseek: apiKeys.deepseek || process.env.DEEPSEEK_API_KEY,
     };
+
+    // Allow overriding the Grok model via environment variable
+    this.grokModel = process.env.GROK_MODEL || 'grok-3-mini-fast-latest';
   }
 
   /**
@@ -168,7 +171,8 @@ Keep your explanation concise and focus only on this specific game.`;
       const response = await this.requestWithRetry(() => axios.post(
         'https://api.x.ai/v1/chat/completions',
         {
-          model: 'grok-1',
+          model: this.grokModel,
+          reasoning_effort: 'low',
           messages: [
             { role: 'system', content: 'You are a sports prediction AI specializing in MLB baseball.' },
             { role: 'user', content: prompt }


### PR DESCRIPTION
## Summary
- allow specifying the Grok model via `GROK_MODEL`
- default model is `grok-3-mini-fast-latest`
- document new variable in README and `.env.example`
- add `reasoning_effort` to Grok requests

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840fc3fb1c88329909b66d55976d359