### PR TITLE
Fix API fallback for predictions

### DIFF
--- a/scripts/llm-integration/mongodb-service.js
+++ b/scripts/llm-integration/mongodb-service.js
@@ -172,6 +172,33 @@ class MongoDBService {
   }
 
   /**
+   * Get the most recently updated predictions
+   * @param {number} limit - Max number of games to return
+   * @returns {Promise<Array>} - Array of game predictions
+   */
+  async getLatestPredictions(limit = 15) {
+    if (!this.predictions) {
+      const connected = await this.connect();
+      if (!connected) {
+        return [];
+      }
+    }
+
+    try {
+      const results = await this.predictions
+        .find()
+        .sort({ updatedAt: -1 })
+        .limit(limit)
+        .toArray();
+
+      return results;
+    } catch (error) {
+      console.error('Error getting latest predictions:', error);
+      return [];
+    }
+  }
+
+  /**
    * Delete predictions for a game
    * @param {String} gameId - Game ID
    * @returns {Promise<boolean>} - Success status


### PR DESCRIPTION
## Summary
- add `getLatestPredictions` helper in MongoDB service
- use latest predictions when no data found for today's date

## Testing
- `npm install`
- `node -e "require('./server')"`

------
https://chatgpt.com/codex/tasks/task_e_6840fdb4507c8329987c114fd2513ccb