### PR TITLE
Fix predictions display and ET date handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,15 +106,27 @@ function renderGames(games){
       <div class="team"><div class="team-logo"><img src="${g.homeTeam.logo}" alt="${g.homeTeam.abbreviation}"></div><div>${g.homeTeam.abbreviation}</div></div>
     </div>
     <div class="game-details" style="text-align:center;padding-bottom:0.5rem;font-size:0.9rem;">${new Date(g.gameTime).toLocaleString('en-US',{timeZone:'America/New_York',hour:'numeric',minute:'2-digit',hour12:true,timeZoneName:'short'})} - ${g.venue}</div>
-    <button onclick="togglePredictions(this)">Show Predictions</button>
+    <button onclick="togglePredictions(this)" data-game-id="${g.gameId}">Show Predictions</button>
     <div class="predictions"><ul>${g.predictions.map(p=>`<li><strong>${p.source}:</strong> ${p.text}</li>`).join('')}</ul></div>`;
     container.appendChild(card);
   });
 }
-function togglePredictions(btn){
-  const p=btn.nextElementSibling;
+async function togglePredictions(btn){
+  const p = btn.nextElementSibling;
+  if (!p.dataset.loaded) {
+    try {
+      const res = await fetch(`/api/games/${btn.dataset.gameId}`);
+      if (res.ok) {
+        const data = await res.json();
+        p.innerHTML = `<ul>${data.predictions.map(pr => `<li><strong>${pr.source}:</strong> ${pr.text}</li>`).join('')}</ul>`;
+        p.dataset.loaded = 'true';
+      }
+    } catch(e){
+      console.error('Failed to load predictions', e);
+    }
+  }
   p.classList.toggle('active');
-  btn.textContent=p.classList.contains('active')?'Hide Predictions':'Show Predictions';
+  btn.textContent = p.classList.contains('active') ? 'Hide Predictions' : 'Show Predictions';
 }
 loadGames();
 </script>


### PR DESCRIPTION
## Summary
- ensure server queries for games using Eastern Time
- add endpoint to retrieve predictions for a single game
- filter predictions to only LLM text fields
- support `data-game-id` and lazy load predictions on button click

## Testing
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_684100fe71588329830bfc82ccb8c2ee